### PR TITLE
More options with labels, more styling choices in customize attributes

### DIFF
--- a/src/state-card-custom-ui.html
+++ b/src/state-card-custom-ui.html
@@ -30,36 +30,75 @@ Polymer({
     'inputChanged(hass, inDialog, stateObj)',
   ],
 
-  badgeMode: function (hass, stateObj) {
+  badgeMode: function (hass, stateObj, badgeLabelBorder, badgeLabelText, badgeBackground) {
     var states = [];
-    stateObj.attributes.entity_id.forEach((id) => {
-      var state = hass.states[id];
-      if (!state) {
-        /* eslint-disable no-console */
-        console.warn('Unknown ID ' + id + ' in group ' + stateObj.entity_id);
-        /* eslint-enable no-console */
-        return;
-      }
-      if (!stateObj.attributes.badges_list ||
-          stateObj.attributes.badges_list.indexOf(state.entity_id) >= 0) {
-        states.push(window.customUI.maybeChangeObject(
-          this, state, false /* inDialog */, false /* allowHidden */));
-      }
-    });
+    if ( typeof stateObj.attributes.entity_id !== 'undefined' && window.hassUtil.computeDomain(stateObj) === 'group' ) {
+      stateObj.attributes.entity_id.forEach((id) => {
+        var state = hass.states[id];
+        if (!state) {
+          /* eslint-disable no-console */
+          console.warn('Unknown ID ' + id + ' in group ' + stateObj.entity_id);
+          /* eslint-enable no-console */
+          return;
+        }
+        if (!stateObj.attributes.badges_list ||
+            stateObj.attributes.badges_list.indexOf(state.entity_id) >= 0) {
+          states.push(window.customUI.maybeChangeObject(
+            this, state, false /* inDialog */, false /* allowHidden */));
+        }
+      });
+    } else {
+        var state = hass.states[stateObj.entity_id];
+        if (!state) {
+          /* eslint-disable no-console */
+          console.warn('Unknown ID ' + stateObj.entity_id + ' in group ' + stateObj.entity_id);
+          /* eslint-enable no-console */
+          return;
+        }
+        if (!stateObj.attributes.badges_list ||
+            stateObj.attributes.badges_list.indexOf(state.entity_id) >= 0) {
+          states.push(window.customUI.maybeChangeObject(
+            this, state, false /* inDialog */, false /* allowHidden */));
+        }
+    }
     window.hassUtil.dynamicContentUpdater(
       this,
       'HA-BADGES-CARD',
       { hass: hass, states: states });
     Polymer.dom(this).lastChild.style.setProperty('--ha-state-label-badge-margin-bottom', '0');
+    Polymer.dom(this).lastChild.style.setProperty('--label-badge-red', badgeLabelBorder);
+    Polymer.dom(this).lastChild.style.setProperty('--label-badge-text-color', badgeLabelText);
+    Polymer.dom(this).parentNode.parentNode.style.setProperty('background-color', badgeBackground);
+    Polymer.dom(this).parentNode.parentNode.style.setProperty('display', 'inline-block');
+    Polymer.dom(this).parentNode.parentNode.style.setProperty('padding', '4px 10px');
   },
 
   inputChanged: function (hass, inDialog, stateObj) {
     var stateCardType;
     var domain;
+    var badgeLabelBorder;
+    var badgeLabelText;
+    var badgeBackground;
     if (!stateObj || !hass || !this.isAttached) return;
     domain = window.hassUtil.computeDomain(stateObj);
-    if (!inDialog && domain === 'group' && stateObj.attributes.state_card_mode === 'badges') {
-      this.badgeMode(hass, stateObj);
+    if (!inDialog && stateObj.attributes.state_card_mode === 'badges') {
+    // if (!inDialog && domain === 'group' && stateObj.attributes.state_card_mode === 'badges') {
+      if (typeof stateObj.attributes.label_badge_color !== 'undefined') {
+        badgeLabelBorder = stateObj.attributes.label_badge_color;
+      } else {
+        badgeLabelBorder = 'var(--label-badge-red)';
+      }
+      if (typeof stateObj.attributes.label_badge_text_color !== 'undefined') {
+        badgeLabelText = stateObj.attributes.label_badge_text_color;
+      } else {
+        badgeLabelText = 'var(--label-badge-text-color)';
+      }
+      if (typeof stateObj.attributes.background !== 'undefined') {
+        badgeBackground = stateObj.attributes.background;
+      } else {
+        badgeBackground = 'transparent';
+      }
+      this.badgeMode(hass, stateObj, badgeLabelBorder, badgeLabelText, badgeBackground, domain);
       return;
     }
     var modifiedObj = window.customUI.maybeChangeObject(

--- a/src/state-card-custom-ui.html
+++ b/src/state-card-custom-ui.html
@@ -68,9 +68,11 @@ Polymer({
     Polymer.dom(this).lastChild.style.setProperty('--ha-state-label-badge-margin-bottom', '0');
     Polymer.dom(this).lastChild.style.setProperty('--label-badge-red', badgeLabelBorder);
     Polymer.dom(this).lastChild.style.setProperty('--label-badge-text-color', badgeLabelText);
-    Polymer.dom(this).parentNode.parentNode.style.setProperty('background-color', badgeBackground);
-    Polymer.dom(this).parentNode.parentNode.style.setProperty('display', 'inline-block');
-    Polymer.dom(this).parentNode.parentNode.style.setProperty('padding', '4px 10px');
+    Polymer.dom(this).lastChild.style.setProperty('--label-badge-background-color', badgeBackground);
+    if (Polymer.dom(this).parentNode.parentNode.tagName === "DIV" && Polymer.dom(this).parentNode.parentNode.classList.contains('state')) {
+      Polymer.dom(this).parentNode.parentNode.style.setProperty('display', 'inline-block');
+      Polymer.dom(this).parentNode.parentNode.style.setProperty('padding', '4px 10px');
+    }
   },
 
   inputChanged: function (hass, inDialog, stateObj) {
@@ -82,7 +84,6 @@ Polymer({
     if (!stateObj || !hass || !this.isAttached) return;
     domain = window.hassUtil.computeDomain(stateObj);
     if (!inDialog && stateObj.attributes.state_card_mode === 'badges') {
-    // if (!inDialog && domain === 'group' && stateObj.attributes.state_card_mode === 'badges') {
       if (typeof stateObj.attributes.label_badge_color !== 'undefined') {
         badgeLabelBorder = stateObj.attributes.label_badge_color;
       } else {
@@ -93,10 +94,10 @@ Polymer({
       } else {
         badgeLabelText = 'var(--label-badge-text-color)';
       }
-      if (typeof stateObj.attributes.background !== 'undefined') {
-        badgeBackground = stateObj.attributes.background;
+      if (typeof stateObj.attributes.label_background_color !== 'undefined') {
+        badgeBackground = stateObj.attributes.label_background_color;
       } else {
-        badgeBackground = 'transparent';
+        badgeBackground = 'var(--label-badge-background-color)';
       }
       this.badgeMode(hass, stateObj, badgeLabelBorder, badgeLabelText, badgeBackground, domain);
       return;
@@ -126,6 +127,11 @@ Polymer({
     } else if (modifiedObj.attributes.theme) {
       window.hassUtil.applyThemesOnElement(
         this, hass.themes, modifiedObj.attributes.theme);
+    }
+    if (modifiedObj.attributes.background_color) {
+      if (Polymer.dom(this).parentNode.parentNode.tagName === "DIV" && Polymer.dom(this).parentNode.parentNode.classList.contains('state')) {
+        Polymer.dom(this).parentNode.parentNode.style.setProperty('background-color', modifiedObj.attributes.background_color);
+      }
     }
 
     var params = {

--- a/src/state-card-custom-ui.html
+++ b/src/state-card-custom-ui.html
@@ -48,18 +48,15 @@ Polymer({
         }
       });
     } else {
-        var state = hass.states[stateObj.entity_id];
+        var state = stateObj;
         if (!state) {
           /* eslint-disable no-console */
           console.warn('Unknown ID ' + stateObj.entity_id + ' in group ' + stateObj.entity_id);
           /* eslint-enable no-console */
           return;
         }
-        if (!stateObj.attributes.badges_list ||
-            stateObj.attributes.badges_list.indexOf(state.entity_id) >= 0) {
-          states.push(window.customUI.maybeChangeObject(
-            this, state, false /* inDialog */, false /* allowHidden */));
-        }
+        states.push(window.customUI.maybeChangeObject(
+          this, state, false /* inDialog */, false /* allowHidden */));
     }
     window.hassUtil.dynamicContentUpdater(
       this,
@@ -77,29 +74,27 @@ Polymer({
 
   inputChanged: function (hass, inDialog, stateObj) {
     var stateCardType;
-    var domain;
     var badgeLabelBorder;
     var badgeLabelText;
     var badgeBackground;
     if (!stateObj || !hass || !this.isAttached) return;
-    domain = window.hassUtil.computeDomain(stateObj);
     if (!inDialog && stateObj.attributes.state_card_mode === 'badges') {
-      if (typeof stateObj.attributes.label_badge_color !== 'undefined') {
+      if (stateObj.attributes.label_badge_color) {
         badgeLabelBorder = stateObj.attributes.label_badge_color;
       } else {
         badgeLabelBorder = 'var(--label-badge-red)';
       }
-      if (typeof stateObj.attributes.label_badge_text_color !== 'undefined') {
+      if (stateObj.attributes.label_badge_text_color) {
         badgeLabelText = stateObj.attributes.label_badge_text_color;
       } else {
         badgeLabelText = 'var(--label-badge-text-color)';
       }
-      if (typeof stateObj.attributes.label_background_color !== 'undefined') {
+      if (stateObj.attributes.label_background_color) {
         badgeBackground = stateObj.attributes.label_background_color;
       } else {
         badgeBackground = 'var(--label-badge-background-color)';
       }
-      this.badgeMode(hass, stateObj, badgeLabelBorder, badgeLabelText, badgeBackground, domain);
+      this.badgeMode(hass, stateObj, badgeLabelBorder, badgeLabelText, badgeBackground);
       return;
     }
     var modifiedObj = window.customUI.maybeChangeObject(
@@ -132,6 +127,8 @@ Polymer({
       if (Polymer.dom(this).parentNode.parentNode.tagName === "DIV" && Polymer.dom(this).parentNode.parentNode.classList.contains('state')) {
         Polymer.dom(this).parentNode.parentNode.style.setProperty('background-color', modifiedObj.attributes.background_color);
       }
+    } else {
+      Polymer.dom(this).parentNode.parentNode.style.setProperty('background-color', 'transparent');
     }
 
     var params = {


### PR DESCRIPTION
Goals is to add more flexibility in colouring the customUI parts that can not be modified by templating: the labels and background colours.

To this end, this pull request includes;
- possibility to set an individual label badge colour, label badge background colour, and label badge text colour in the customize yaml file
- changed the rules so that it is also possible to make any state card into a badge label, not just groups anymore -- to simplify the complicated "groups-within-groups" rules.
- possibility to set a state's overall background colour (only in the state card, not the more-info dialog popups) to a set colour

Possible improvements/expansion of this pull request could be;
- clean up my code (I'm not a JS expert!)
- add templates to overrule the colours (just as you did with the theme_template), to have an attribute change colour with the value