### PR TITLE
Update hooks.js for icon_color in Ha 0.110+

### DIFF
--- a/src/utils/hooks.js
+++ b/src/utils/hooks.js
@@ -504,10 +504,8 @@ window.customUI = window.customUI || {
           const { stateObj } = this;
           if (stateObj.attributes.icon_color && !stateObj.attributes.entity_picture) {
             this.style.backgroundImage = '';
-            Object.assign(this._icon.style, {
-              color: stateObj.attributes.icon_color,
-              filter: '',
-            });
+            this._showIcon = true;
+            this._iconStyle = {color: stateObj.attributes.icon_color;}
           } else {
             originalUpdated.call(this, changedProps);
           }


### PR DESCRIPTION
needed to be able to use icon_color in Ha 110 upward.

see: https://github.com/home-assistant/frontend/issues/5892#issuecomment-630872617